### PR TITLE
Fix OUStrategy to include ou_state when returning action

### DIFF
--- a/rllab/exploration_strategies/ou_strategy.py
+++ b/rllab/exploration_strategies/ou_strategy.py
@@ -50,7 +50,7 @@ class OUStrategy(ExplorationStrategy, Serializable):
     def get_action(self, t, observation, policy, **kwargs):
         action, _ = policy.get_action(observation)
         ou_state = self.evolve_state()
-        return np.clip(action + np.random.normal(size=len(action)), self.action_space.low, self.action_space.high)
+        return np.clip(action + ou_state, self.action_space.low, self.action_space.high)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix OUStrategy by including ou_state noise instead of Gaussian noise when returning the action.
