### PR TITLE
add flattening logic so ddpg can handle image observations

### DIFF
--- a/rllab/algos/ddpg.py
+++ b/rllab/algos/ddpg.py
@@ -224,7 +224,7 @@ class DDPG(RLAlgorithm):
                     self.es_path_returns.append(path_return)
                     path_length = 0
                     path_return = 0
-                action = self.es.get_action(itr, observation, policy=sample_policy)  # qf=qf)
+                action = self.es.get_action(itr, self.env.observation_space.flatten(observation), policy=sample_policy)  # qf=qf)
 
                 next_observation, reward, terminal, _ = self.env.step(action)
                 path_length += 1
@@ -234,10 +234,19 @@ class DDPG(RLAlgorithm):
                     terminal = True
                     # only include the terminal transition in this case if the flag was set
                     if self.include_horizon_terminal_transitions:
-                        pool.add_sample(observation, action, reward * self.scale_reward, terminal)
+                        pool.add_sample(
+                            self.env.observation_space.flatten(observation),
+                            self.env.action_space.flatten(action),
+                            reward * self.scale_reward,
+                            terminal
+                        )
                 else:
-                    pool.add_sample(observation, action, reward * self.scale_reward, terminal)
-
+                    pool.add_sample(
+                        self.env.observation_space.flatten(observation),
+                        self.env.action_space.flatten(action),
+                        reward * self.scale_reward,
+                        terminal
+                    )
                 observation = next_observation
 
                 if pool.size >= self.min_pool_size:

--- a/rllab/algos/ddpg.py
+++ b/rllab/algos/ddpg.py
@@ -224,7 +224,7 @@ class DDPG(RLAlgorithm):
                     self.es_path_returns.append(path_return)
                     path_length = 0
                     path_return = 0
-                action = self.es.get_action(itr, self.env.observation_space.flatten(observation), policy=sample_policy)  # qf=qf)
+                action = self.es.get_action(itr, observation, policy=sample_policy)  # qf=qf)
 
                 next_observation, reward, terminal, _ = self.env.step(action)
                 path_length += 1

--- a/rllab/policies/deterministic_mlp_policy.py
+++ b/rllab/policies/deterministic_mlp_policy.py
@@ -63,11 +63,13 @@ class DeterministicMLPPolicy(Policy, LasagnePowered, Serializable):
         LasagnePowered.__init__(self, [l_output])
 
     def get_action(self, observation):
-        action = self._f_actions([observation])[0]
+        flat_obs = self.observation_space.flatten(observation)
+        action = self._f_actions([flat_obs])[0]
         return action, dict()
 
     def get_actions(self, observations):
-        return self._f_actions(observations), dict()
+        flat_obs = self.observation_space.flatten_n(observations)
+        return self._f_actions(flat_obs), dict()
 
     def get_action_sym(self, obs_var):
         return L.get_output(self._output_layer, obs_var)

--- a/rllab/sampler/utils.py
+++ b/rllab/sampler/utils.py
@@ -14,7 +14,7 @@ def rollout(env, agent, max_path_length=np.inf, animated=False, speedup=1):
     if animated:
         env.render()
     while path_length < max_path_length:
-        a, agent_info = agent.get_action(env.observation_space.flatten(o))
+        a, agent_info = agent.get_action(o)
         next_o, r, d, env_info = env.step(a)
         observations.append(env.observation_space.flatten(o))
         rewards.append(r)

--- a/rllab/sampler/utils.py
+++ b/rllab/sampler/utils.py
@@ -14,7 +14,7 @@ def rollout(env, agent, max_path_length=np.inf, animated=False, speedup=1):
     if animated:
         env.render()
     while path_length < max_path_length:
-        a, agent_info = agent.get_action(o)
+        a, agent_info = agent.get_action(env.observation_space.flatten(o))
         next_o, r, d, env_info = env.step(a)
         observations.append(env.observation_space.flatten(o))
         rewards.append(r)


### PR DESCRIPTION
Logic to flatten observations that are not a flat vector, allowing the ddpg algorithm to work with environments that return image data in their observations. cf. #22.