### PR TITLE
bugfix: sample_isweighted_paths returns correct paths now

### DIFF
--- a/contrib/alexbeloi/examples/trpois_cartpole.py
+++ b/contrib/alexbeloi/examples/trpois_cartpole.py
@@ -1,0 +1,43 @@
+from rllab.algos.trpo import TRPO
+from rllab.algos.tnpg import TNPG
+from rllab.baselines.linear_feature_baseline import LinearFeatureBaseline
+from rllab.envs.box2d.cartpole_env import CartpoleEnv
+from rllab.envs.normalized_env import normalize
+from rllab.policies.gaussian_mlp_policy import GaussianMLPPolicy
+from contrib.alexbeloi.is_sampler import ISSampler
+
+"""
+Example using VPG with ISSampler, iterations alternate between live and
+importance sampled iterations.
+"""
+
+env = normalize(CartpoleEnv())
+
+policy = GaussianMLPPolicy(
+    env_spec=env.spec,
+    # The neural network policy should have two hidden layers, each with 32 hidden units.
+    hidden_sizes=(32, 32)
+)
+
+baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+optimizer_args = dict(
+    # debug_nan=True,
+    # reg_coeff=0.1,
+    # cg_iters=2
+)
+
+algo = TRPO(
+    env=env,
+    policy=policy,
+    baseline=baseline,
+    batch_size=4000,
+    max_path_length=100,
+    n_itr=200,
+    discount=0.99,
+    step_size=0.01,
+    sampler_cls=ISSampler,
+    sampler_args=dict(n_backtrack=1),
+    optimizer_args=optimizer_args
+)
+algo.train()

--- a/contrib/alexbeloi/is_sampler.py
+++ b/contrib/alexbeloi/is_sampler.py
@@ -112,4 +112,4 @@ class ISSampler(BatchSampler):
             is_ratio = exp(sum(loglike_p) - sum(loglike_hp))
             path['rewards'] *= is_ratio
 
-        return paths
+        return samples


### PR DESCRIPTION
Bugfix for [#24](https://github.com/rllab/rllab/issues/24 "Conjugate Gradient Optimization sometimes fails (with NaN parameters)") ISSampler and an example which uses TRPO algorithm with ISSampler on the cartpole problem.